### PR TITLE
Update CartesianRDD.scala

### DIFF
--- a/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
+++ b/core/src/main/scala/org/apache/spark/rdd/CartesianRDD.scala
@@ -72,8 +72,10 @@ class CartesianRDD[T: ClassTag, U: ClassTag](
 
   override def compute(split: Partition, context: TaskContext): Iterator[(T, U)] = {
     val currSplit = split.asInstanceOf[CartesianPartition]
-    for (x <- rdd1.iterator(currSplit.s1, context);
-         y <- rdd2.iterator(currSplit.s2, context)) yield (x, y)
+    val groupSize = 500 // TODO: tune the groupSize
+    for (x <- rdd1.iterator(currSplit.s1, context).grouped(groupSize);
+         y <- rdd2.iterator(currSplit.s2, context).grouped(groupSize);
+         i <- x; j <- y) yield (x, y)
   }
 
   override def getDependencies: Seq[Dependency[_]] = List(


### PR DESCRIPTION
In compute, group each iterator to multiple groups, reducing repeatedly data fetching.

## What changes were proposed in this pull request?

In compute, group each iterator to multiple groups. Thus in the second iteration, the data with be fetched (num of data)/groupSize times, rather than (num of data) times.

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review http://spark.apache.org/contributing.html before opening a pull request.
